### PR TITLE
fix:Replacing all mentions of UNICOM with Advisory Frequency

### DIFF
--- a/eAIP/airspace/gooo/rules.txt
+++ b/eAIP/airspace/gooo/rules.txt
@@ -21,7 +21,7 @@
 ==== SLOP ====
 
   * The use of SLOP in Dakar Continental is in compliance with provisions in ICAO Doc. 4444, between flight level FL280 and FL460.
-  * Pilots are advised to coordinate offset on UNICOM (122.800).
+  * Pilots are advised to coordinate offset on Advisory Frequency (122.800).
 
 
 {{page>go-footer#GOOO}}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?


## Issue Number and Link
https://github.com/VATSIM-SSA/sectorfile-overview/issues/31

## Describe Your Changes

Replacing all mentions of UNICOM with Advisory Frequency on the eAIP.

Relates to https://github.com/VATSIM-SSA/sectorfile-overview/issues/31

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have tested my changes in my local setup
- [x] My changes generate no new warnings
